### PR TITLE
bugfix: add retry for occasional panic read: connection reset by peer

### DIFF
--- a/pkg/ambient_wx_exporter/metrics/metrics.go
+++ b/pkg/ambient_wx_exporter/metrics/metrics.go
@@ -18,44 +18,51 @@ var apiKeysWithoutMetrics = map[string]bool{
 	"lastRain": true,
 }
 
-func getAmbientDevices(key ambient.Key, logger log.Logger) ambient.APIDeviceResponse {
-	dr, err := ambient.Device(key)
-	if err != nil {
-		panic(err)
-	}
-	switch dr.HTTPResponseCode {
-	case 200:
-	case 429, 502, 503:
-		{
+func getAmbientDevices(key ambient.Key, logger log.Logger) (ambient.APIDeviceResponse, error) {
+	var dr ambient.APIDeviceResponse
+	maxRetries := 5
+	backoff := 1 * time.Second
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		var err error
+		dr, err = ambient.Device(key)
+		if err != nil {
 			level.Warn(logger).Log(
-				"msg", "HTTP error from Ambient API. Retrying.",
-				"status_code", dr.HTTPResponseCode,
+				"msg", "Ambient API request failed",
+				"attempt", attempt,
+				"error", err,
 			)
-			time.Sleep(1 * time.Second)
-			dr, err = ambient.Device(key)
-			if err != nil {
-				panic(err)
-			}
+		} else {
 			switch dr.HTTPResponseCode {
 			case 200:
+				level.Info(logger).Log("msg", "Successfully fetched data from Ambient API")
+				return dr, nil
+			case 429, 502, 503:
+				level.Warn(logger).Log(
+					"msg", "Recoverable HTTP error from Ambient API. Retrying.",
+					"attempt", attempt,
+					"status_code", dr.HTTPResponseCode,
+				)
 			default:
-				{
-					panic(dr)
-				}
+				level.Error(logger).Log(
+					"msg", "Unrecoverable HTTP error from Ambient API.",
+					"status_code", dr.HTTPResponseCode,
+				)
+				return dr, fmt.Errorf("unrecoverable ambient API status %d", dr.HTTPResponseCode)
 			}
 		}
-	default:
-		{
-			level.Error(logger).Log(
-				"msg", "Unrecoverable HTTP error from Ambient API.",
-				"status_code", dr.HTTPResponseCode,
-			)
-			panic(dr)
+
+		if attempt == maxRetries {
+			break
+		}
+
+		time.Sleep(backoff)
+		backoff *= 2
+		if backoff > 30*time.Second {
+			backoff = 30 * time.Second
 		}
 	}
 
-	level.Info(logger).Log("msg", "Succesfully fetched data from Ambient API")
-	return dr
+	return dr, fmt.Errorf("failed to fetch ambient devices after %d attempts", maxRetries)
 }
 
 func recordDeviceMetrics(device ambient.DeviceRecord, theState *state.State, logger log.Logger) {
@@ -138,7 +145,11 @@ func recordDefaultMetrics(device ambient.DeviceRecord, theState *state.State, lo
 }
 
 func recordLoop(key ambient.Key, theState *state.State, logger log.Logger) {
-	dr := getAmbientDevices(key, logger)
+	dr, err := getAmbientDevices(key, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "Unable to fetch Ambient device data", "error", err)
+		return
+	}
 
 	for _, device := range dr.DeviceRecord {
 		level.Info(logger).Log("msg", "Recording device metrics", "mac_address", device.Macaddress)
@@ -150,13 +161,17 @@ func recordLoop(key ambient.Key, theState *state.State, logger log.Logger) {
 			recordDefaultMetrics(device, theState, logger)
 		}
 	}
-
 }
 
 // RecordMetrics spawns a loop to record metrics
 func RecordMetrics(theState *state.State, logger log.Logger) {
 	key := ambient.NewKey(theState.AppKey, theState.APIKey)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				level.Error(logger).Log("msg", "Recovered from metrics worker panic", "error", r)
+			}
+		}()
 		for {
 			recordLoop(key, theState, logger)
 			time.Sleep(60 * time.Second)


### PR DESCRIPTION
Observed following error when running as a container. Supplied fix adds retries with a backoff delay.

```
2026/06/10 00:12:37,stderr,level=info ts=2026-06-10T05:12:37.322293194Z msg="Metrics will be served on http://localhost:9876"
2026/06/10 00:12:26,stderr,     /home/chouse/ambient_wx_exporter/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics/metrics.go:159 +0xf9
2026/06/10 00:12:26,stderr,created by github.com/dantswain/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics.RecordMetrics
2026/06/10 00:12:26,stderr,     /home/chouse/ambient_wx_exporter/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics/metrics.go:161 +0x5c
2026/06/10 00:12:26,stderr,github.com/dantswain/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics.RecordMetrics.func1()
2026/06/10 00:12:26,stderr,     /home/chouse/ambient_wx_exporter/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics/metrics.go:141 +0x5c
2026/06/10 00:12:26,stderr,"github.com/dantswain/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics.recordLoop({{0xc000234240?, 0x40?}, {0xc000234280?, 0x40?}}, 0xc00022a370, {0x96da20, 0xc00021aa80})
2026/06/10 00:12:26,stderr,     /home/chouse/ambient_wx_exporter/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics/metrics.go:24 +0x767
2026/06/10 00:12:26,stderr,"github.com/dantswain/ambient_wx_exporter/pkg/ambient_wx_exporter/metrics.getAmbientDevices({{0xc000234240?, 0x0?}, {0xc000234280?, 0x0?}}, {0x96da20, 0xc00021aa80})
2026/06/10 00:12:26,stderr,goroutine 103 [running]:
2026/06/10 00:12:26,stderr,
2026/06/10 00:12:26,stderr,panic: Get "https://api.ambientweather.net/v1/devices?applicationKey=<app_key>&apiKey=<api_key>": read tcp 172.18.0.4:57714->104.26.6.76:443: read: connection reset by peer
```